### PR TITLE
docs(readme): fix sandbox host and response variable typo in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ import flagright
 from flagright.client import Flagright
 
 
-client = Flagright(base_url="https://sandbox.flagright.com", api_key="YOUR_API_KEY")
-resposne = client.transactions.verify(request=flagright.Transaction(
+client = Flagright(base_url="https://sandbox.api.flagright.com", api_key="YOUR_API_KEY")
+response = client.transactions.verify(request=flagright.Transaction(
     transactionId='my-transaction-id',
     type=flagright.TransactionType.DEPOSIT,
     timestamp=1692624734000))
 
 
-print(f'Received response from Flagright: "{resposne}"')
+print(f'Received response from Flagright: "{response}"')
 ```


### PR DESCRIPTION
## Summary
Fixes two developer-experience issues in the Python SDK README usage snippet:

1. Uses canonical sandbox host `https://sandbox.api.flagright.com`.
2. Fixes typo `resposne` -> `response`.

## Why
The current snippet can create avoidable integration friction for first-time users copying the README example.

## Changes
- Updated `base_url` in usage example.
- Renamed local example variable and print statement to `response`.

## Validation
- README snippet reviewed for consistency with public Node SDK examples.
- No runtime code changes; docs-only change.
